### PR TITLE
Fix guide URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ### External Docs
 
-- [A Guide to Deno Core (Design & For Contributors)](https://denolib.gitbook.io/guide)
+- [A Guide to Deno Core (Design & For Contributors)](https://denolib.gitbook.io/guide/)
 - [V8 Docs for Deno](https://denolib.github.io/v8-docs/)
 
 # Modules


### PR DESCRIPTION
To fix this CI error: 
```
1. [L030] 302 https://denolib.gitbook.io/guide  → https://denolib.gitbook.io/guide/
```
