### PR TITLE
Update colors url

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/registry/bl
 - [bytes_formater](https://github.com/manyuanrong/bytes_formater) - Format bytes (Uint8Array、ArrayBufferView...) output, useful when debugging IO functions.
 - [cac](https://github.com/cacjs/cac) - Simple yet powerful framework for building command-line apps.
 - [camelcase](https://github.com/denolib/camelcase) - Convert a dash/dot/underscore/space separated string to camelCase: foo-bar → fooBar.
-- [colors](https://github.com/denoland/deno_std/tree/master/colors) - A basic console color library intended for Deno.
+- [colors](https://deno.land/std/fmt/colors.ts) - A basic console color library intended for Deno.
 - [cli-spinner](https://github.com/ameerthehacker/cli-spinners) - Show spinners in the terminal while running long tasks
 - [csv](https://github.com/hashrock/deno-fnparse/blob/master/parsers/csv.ts) - A simple CSV parser.
 - [dcc](https://github.com/BoltDoggy/deno#dcc) - Deno Cache Clean, reloading deps when next running.


### PR DESCRIPTION
`colors` module has been moved under /std/fmt/ ( https://github.com/denoland/deno_std/pull/571 ), and now it doesn't have its own README. So I linked it to the page on deno.land.