### PR TITLE
Add `denox` workspace wrapper around Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 - [denon](https://github.com/eliassjogreen/denon) - Like Nodemon, but for Deno
 - [denopkg](https://github.com/denopkg/denopkg.com) - An easier way to use code from GitHub in your Deno project.
 - [denoversion](https://github.com/lucascaro/denoversion) - SemVer+git version management for Deno.
-- [denox](https://github.com/BentoumiTech/denox) - Like packages.json scripts, but for Deno with permissions hardcoded in file.
+- [denox](https://github.com/BentoumiTech/denox) - Like packages.json scripts, but for Deno with permissions hardcoded in a file.
 - [deno.mk](https://github.com/MarkTiedemann/deno.mk) - Cross-platform Makefile for installing and running Deno.
 - maxmcd's [deno-docker](https://github.com/maxmcd/deno-docker) A docker image.
 - hayd's [deno-docker](https://github.com/hayd/deno-docker) Several docker images.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 - [denon](https://github.com/eliassjogreen/denon) - Like Nodemon, but for Deno
 - [denopkg](https://github.com/denopkg/denopkg.com) - An easier way to use code from GitHub in your Deno project.
 - [denoversion](https://github.com/lucascaro/denoversion) - SemVer+git version management for Deno.
-- [denox](https://github.com/BentoumiTech/denox) - Like packages.json scripts, but for Deno with permissions hardcoded in a file.
+- [denox](https://github.com/BentoumiTech/denox) - Like packages.json scripts, but for Deno with permissions support.
 - [deno.mk](https://github.com/MarkTiedemann/deno.mk) - Cross-platform Makefile for installing and running Deno.
 - maxmcd's [deno-docker](https://github.com/maxmcd/deno-docker) A docker image.
 - hayd's [deno-docker](https://github.com/hayd/deno-docker) Several docker images.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 - [denon](https://github.com/eliassjogreen/denon) - Like Nodemon, but for Deno
 - [denopkg](https://github.com/denopkg/denopkg.com) - An easier way to use code from GitHub in your Deno project.
 - [denoversion](https://github.com/lucascaro/denoversion) - SemVer+git version management for Deno.
+- [denox](https://github.com/BentoumiTech/denox) - Like packages.json scripts, but for Deno with permissions hardcoded in file.
 - [deno.mk](https://github.com/MarkTiedemann/deno.mk) - Cross-platform Makefile for installing and running Deno.
 - maxmcd's [deno-docker](https://github.com/maxmcd/deno-docker) A docker image.
 - hayd's [deno-docker](https://github.com/hayd/deno-docker) Several docker images.


### PR DESCRIPTION
Like packages.json scripts, but for Deno with permissions hardcoded in a file.

```yaml
scripts:
  # "denox run start" will execute main.ts with example.com networking permissions
  start:
    file: main.ts
    permissions:
      allow-net: example.com
  # "denox run develop" will execute main.ts with localhost networking permissions
  develop:
    file: main.ts
    permissions:
      allow-net: localhost
```