### PR TITLE
Remove https://adarshron.com/introducing-deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 - [What’s Deno, and how is it different from Node.js?](https://dev.to/bnevilleoneill/what-s-deno-and-how-is-it-different-from-node-js-366g)
 - [Write a small API using Deno](https://dev.to/kryz/write-a-small-api-using-deno-1cl0)
 - [Deno on AWS Lambda with Architect or SAM](https://blog.begin.com/deno-runtime-support-for-architect-805fcbaa82c3)
-- [Introducing Deno - NodeJS Killer](https://adarshron.com/introducing-deno)
 
 # Presentations
 


### PR DESCRIPTION
The cert expired on this page and it fails the CI. Removing it. Please re-add it if the problem fixed.