### PR TITLE
fix: allow 429 errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
           ruby-version: 2.6.x
       - run: |
           gem install awesome_bot
-          awesome_bot README.md --allow-redirect -w https://deno.land/x/,https://deno.land/std/,https://deno.land
+          awesome_bot README.md --allow 429 --allow-redirect -w https://deno.land/x/,https://deno.land/std/,https://deno.land


### PR DESCRIPTION
Allow 429 errors, do not have better solution.
https://github.com/dkhamsing/awesome_bot does not have issue feature activated. For the current state it fixes the CI.