### PR TITLE
Add playground link to deno-playground.now.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This list is a collection of the best Deno modules and resources.
 ### Online Playgrounds
 
 - [deno.town](https://deno.town)
+- [Deno Playground](https://deno-playground.now.sh)
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This list is a collection of the best Deno modules and resources.
 
 - [deno.town](https://deno.town)
 - [Deno Playground](https://deno-playground.now.sh)
+  - [maman/deno-playground](https://github.com/maman/deno-playground)
 
 ## Modules
 


### PR DESCRIPTION
I'm adding more online playgrounds for deno, available here: https://deno-playground.now.sh

the repo is also available at [maman/deno-playground](https://github.com/maman/deno-playground)