### PR TITLE
Telegram Bot Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ This list is a collection of the best Deno modules and resources.
 - [Deno Playground](https://deno-playground.now.sh)
   - [maman/deno-playground](https://github.com/maman/deno-playground)
 
+### Assistants
+
+- [Telegram Bot Assistant](https://t.me/denoland_bot)
+- [Source code of the bot](https://github.com/genemators/lander.js)
+
 ## Modules
 
 __NOTICE__: Deno has a few official modules that could be found at [deno_std](https://deno.land/std/).


### PR DESCRIPTION
Hello Dear Deno Contributors, yesterday I created a telegram bot that can give details about updates of deno. Also, on inline mode it searches third party modules and routes to deno.land/x/package. On upcoming features, I want to cover doc routes and all other api of deno. I'd be very thankful if you confirm my request. Thanks for your attention)