### PR TITLE
Add websocket_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 - [up](https://github.com/denorg/up) - Check if a website is up in Deno.
 - [wasm-gzip](https://github.com/manyuanrong/wasm_gzip) - Encrypt and decrypt gzip for Deno.
 - [watch](https://github.com/jinjor/deno-watch) - A file watcher.
-- [websocket_server](https://github.com/JohanWinther/websocket_server) - A WebSocket server library for Deno. 🔌
+- [websocket_server](https://github.com/JohanWinther/websocket_server) - A WebSocket server library. 🔌
 - [webview](https://github.com/eliassjogreen/deno_webview) - Deno bindings for webview, a tiny library for creating web-based desktop GUIs.
 - [wu-diff-js](https://github.com/bokuweb/wu-diff-js) - A diff library to compute differences between two slices using wu(the O(NP)) algorithm.
 - [youtube-deno](https://github.com/akshgpt7/youtube-deno) - A Deno client library for the YouTube Data API for any interaction with YouTube.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 - [up](https://github.com/denorg/up) - Check if a website is up in Deno.
 - [wasm-gzip](https://github.com/manyuanrong/wasm_gzip) - Encrypt and decrypt gzip for Deno.
 - [watch](https://github.com/jinjor/deno-watch) - A file watcher.
+- [websocket_server](https://github.com/JohanWinther/websocket_server) - A WebSocket server library for Deno 🔌
 - [webview](https://github.com/eliassjogreen/deno_webview) - Deno bindings for webview, a tiny library for creating web-based desktop GUIs.
 - [wu-diff-js](https://github.com/bokuweb/wu-diff-js) - A diff library to compute differences between two slices using wu(the O(NP)) algorithm.
 - [youtube-deno](https://github.com/akshgpt7/youtube-deno) - A Deno client library for the YouTube Data API for any interaction with YouTube.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 - [up](https://github.com/denorg/up) - Check if a website is up in Deno.
 - [wasm-gzip](https://github.com/manyuanrong/wasm_gzip) - Encrypt and decrypt gzip for Deno.
 - [watch](https://github.com/jinjor/deno-watch) - A file watcher.
-- [websocket_server](https://github.com/JohanWinther/websocket_server) - A WebSocket server library for Deno 🔌
+- [websocket_server](https://github.com/JohanWinther/websocket_server) - A WebSocket server library for Deno. 🔌
 - [webview](https://github.com/eliassjogreen/deno_webview) - Deno bindings for webview, a tiny library for creating web-based desktop GUIs.
 - [wu-diff-js](https://github.com/bokuweb/wu-diff-js) - A diff library to compute differences between two slices using wu(the O(NP)) algorithm.
 - [youtube-deno](https://github.com/akshgpt7/youtube-deno) - A Deno client library for the YouTube Data API for any interaction with YouTube.


### PR DESCRIPTION
The [websocket_server](https://github.com/JohanWinther/websocket_server) package is a WebSocket server library.

It provides a server class which implements an asyncIterable instead of using the event/callback pattern (which [ryo-ma/deno-websocket](https://github.com/ryo-ma/deno-websocket) uses).