### PR TITLE
Remove md5 as a third party module

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 - [dejs](https://github.com/syumai/dejs) - Ejs template engine for deno.
 - [denon](https://github.com/denosaurs/denon/blob/master/mod.ts) - A file watcher with a for-await generator.
 - [deno_case_style](https://github.com/zekth/deno_case_style) - String validator and formater for different case style. eg: camelCase etc.
-- [deno-checksum](https://github.com/manyuanrong/deno-checksum) - SHA1/MD5 algorithms.
 - [deno-context](https://github.com/code-hex/deno-context) - Propagate deadlines, a cancellation and other request-scoped values to multiple promise. The behaviour is like Go's context.
 - [deno_cron](https://github.com/rbrahul/deno_cron) - A cron Job scheduler that allows you to write human readable cron syntax with tons of flexibility
 - [deno-deamon](https://github.com/manyuanrong/deno-deamon) - Make the Deno program run in the background.


### PR DESCRIPTION
Given that MD5 and base hash functions are already supported as part of `std/hash` by now (https://github.com/denoland/deno/pull/5719) I think it's miss leading to recommend a third party module.
MD5 generation is nothing but - https://gist.github.com/AvnerCohen/d056dc1aedbf336f2df0bbed040b2d8e
So I suggest to instead recommend standard libs.