### PR TITLE
Add deno_notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 - [deno-globrex](https://github.com/hayd/deno-globrex) - Port of globrex to deno, glob to regular expression.
 - [deno-mysql](https://github.com/manyuanrong/deno_mysql) - MySQL database driver.
 - [deno_mongo](https://github.com/manyuanrong/deno_mongo) - MongoDB database driver.
+- [deno_notify](https://github.com/PandawanFr/deno_notify) - Send desktop notifications on all platforms.
 - [deno-opn](https://github.com/hashrock/deno-opn) - Opens stuff like websites, files, executables. Cross-platform.
 - [deno-plugin-prepare](https://github.com/manyuanrong/deno-plugin-prepare) - A library for managing Deno native plugin dependencies.
 - [deno-pretty-assert](https://github.com/bokuweb/deno-pretty-assert) - A colorful assertEqual for deno.


### PR DESCRIPTION
[deno_notify](https://github.com/PandawanFr/deno_notify) allows you to send desktop notifications on all platforms.  
It has already been added to deno.land/x so I just thought I'd add it do awesome-deno as well.