### PR TITLE
remove article "Making APIs in Deno"

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 - [Learn Deno: Chat app](https://aralroca.com/blog/learn-deno-chat-app)
 - [From Node to Deno](https://dev.to/aralroca/from-node-to-deno-5gpn)
 - [Create a simple Note-taking app with Deno](https://dev.to/jeferson_sb/create-a-simple-note-taking-app-with-deno-3k7g)
-- [Making APIs in Deno](https://medium.com/swlh/making-apis-in-deno-83dedda9dd1f?source=friends_link&sk=396c0dee437989ba3d2c2cc46d7d5933)
 - [Develop and Dockerize a Blogging API With Deno, Oak, and MySQL](https://dev.to/fhsinchy/develop-and-dockerize-a-blogging-api-with-deno-oak-and-mysql-170e)
 
 ## Presentations


### PR DESCRIPTION
This page returns 410 status and seems unavailable.