### PR TITLE
Add article: Create your first News CLI app using Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 - [Building API's using Deno, Oak and MYSQL](https://codeforgeek.com/building-api-server-using-deno-and-mysql/)
 - [Create interactive mail utility CLI Tool using Deno
 ](https://www.soubai.me/posts/create-interactive-mail-utility-cli-with-deno)
+- [Create your first News CLI app using Deno](https://medium.com/javascript-in-plain-english/creating-your-first-news-cli-app-using-deno-e1470398c627)
 
 ## Presentations
 


### PR DESCRIPTION
Adds [Create your first News CLI app using Deno](https://medium.com/javascript-in-plain-english/creating-your-first-news-cli-app-using-deno-e1470398c627) article.
This article is different as it covers most of the basic concepts of Deno, compares and contrasts the design choices of Deno with NodeJS, providing a better foundation for a Deno beginner.