### PR TITLE
Add superdeno to modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 - [sax-ts](https://github.com/Maxim-Mazurok/sax-ts) - SAX-style XML parser ported from [sax-js](https://github.com/isaacs/sax-js).
 - [servest](https://github.com/keroxp/servest) - A progressive HTTP server/router.
 - [sockets](https://github.com/drashland/sockets) - A WebSocket library for Deno.
+- [superdeno](https://github.com/asos-craigmorten/superdeno) - Super-agent driven library for testing Deno HTTP servers.
 - [sql-builder](https://github.com/manyuanrong/sql-builder) - An sql query builder.
 - [status](https://github.com/denosaurs/status) - HTTP codes and status utility for Deno.
 - [task-runner-v2](https://github.com/ebebbington/deno-task-runner-v2) - Version 2 of deno-task-runner to fix issues

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This list is a collection of the best Deno modules and resources.
 ## Modules
 
 __NOTICE__: Deno has a few official modules that could be found at [deno_std](https://deno.land/std/).
-Consider submitting to [the deno.land/x](https://github.com/denoland/deno_website2/blob/master/database.json) repository.
+Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 
 - [abc](https://github.com/zhmushan/abc) - A better Deno framework to create web application.
 - [alosaur](https://github.com/alosaur/alosaur) - Alosaur - Deno web framework with many decorators.


### PR DESCRIPTION
This PR adds [superdeno](https://github.com/asos-craigmorten/superdeno) - _Super-agent driven library for testing Deno HTTP servers_.

superdeno allows Deno programmers to test their HTTP servers in same way [supertest](https://github.com/visionmedia/supertest) does for Node packages.