### PR TITLE
Add Article: Continuous Integration with Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 ](https://www.soubai.me/posts/create-interactive-mail-utility-cli-with-deno)
 - [Create your first News CLI app using Deno](https://medium.com/javascript-in-plain-english/creating-your-first-news-cli-app-using-deno-e1470398c627)
 - [Deploy a Deno Application on AWS Using Docker and Travis CI](https://dev.to/fhsinchy/deploy-a-deno-application-on-aws-using-docker-and-travis-ci-4p8o)
+- [Continuous Integration with Deno](https://semaphoreci.com/blog/continuous-integration-with-deno)
 
 ## Presentations
 


### PR DESCRIPTION
This is a tutorial on getting started with Continuous Integration with Deno and using Docker to run your Deno applications.

Link: https://semaphoreci.com/blog/continuous-integration-with-deno
Title: Continuous Integration with Deno

I didn't find any other CI/CD articles on the list, so I think this may come in handy to anyone trying to deploy applications with Deno.