### PR TITLE
Add context-finder to modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Consider submitting to [the deno.land/x](https://github.com/denoland/deno_websit
 - [camelcase](https://github.com/denolib/camelcase) - Convert a dash/dot/underscore/space separated string to camelCase: foo-bar → fooBar.
 - [colors](https://deno.land/std/fmt/colors.ts) - A basic console color library intended for Deno.
 - [computed_types](https://github.com/neuledge/computed-types) - Joi like validators for Typescript and Deno.
+- [context-finder](https://github.com/ebebbington/deno-context-finder) - Extract context blocks from a configuration file
 - [cli-spinner](https://github.com/ameerthehacker/cli-spinners) - Show spinners in the terminal while running long tasks.
 - [csv](https://github.com/hashrock/deno-fnparse/blob/master/parsers/csv.ts) - A simple CSV parser.
 - [dcc](https://github.com/BoltDoggy/deno#dcc) - Deno Cache Clean, reloading deps when next running.


### PR DESCRIPTION
https://github.com/ebebbington/deno-context-finder

Deno-Context-Finder is a module for a specific use case, to extract configuration blocks from a config file - usually for Asterisk conf blocks

Original built for someone in Node who had a usecase, then ported to Deno to cater to a wider audience 