### PR TITLE
Add Eta to the Modules section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 - [drash](https://github.com/drashland/deno-drash) - A REST microframework for Deno's HTTP server with zero dependencies.
 - [dso](https://github.com/manyuanrong/dso) - A simple ORM library based on mysql.
 - [ensure](https://github.com/eankeen/ensure) - Ensure you are running a minimum version of Deno, Typescript, or V8.
+- [eta](https://github.com/eta-dev/eta) - Fast, lightweight, and configurable embedded template engine.
 - [evt](https://github.com/garronej/evt) - Type safe replacement for EventEmitter.
 - [expect](https://github.com/allain/expect) - Helpers for writing jest like expect tests in deno.
 - [flags](https://github.com/denoland/deno_std/tree/master/flags) - Command line arguments parser for Deno based on minimist.


### PR DESCRIPTION
[Eta](https://eta.js.org) is an embedded template engine similar to EJS and doT. It's very fast, configurable, and supports plugins. Examples of Deno projects using Eta exist for [Opine](https://github.com/asos-craigmorten/opine/tree/main/examples/eta) and [Alosaur](https://github.com/alosaur/alosaur/tree/master/examples/eta).

_Similar packages_
The two other template engines on the list are [dejs](https://github.com/syumai/dejs) and [deno_tiny_templates](https://github.com/zekth/deno_tiny_templates). Though these are cool modules, I think Eta is more powerful, more reliable, better tested, and has better documentation.

Thanks for creating this awesome repo!