### PR TITLE
Add GitHub Profile Trophy to Showcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 
 - [Deno Seed](https://github.com/tamasszoke/deno-seed) - Complete boilerplate for development. :seedling:
 - [UsingDeno](https://usingdeno.com) - Curated list of Web Applications & Projects using Deno 🦕.
+- [GitHub Profile Trophy](https://github.com/ryo-ma/github-profile-trophy) - 🏆 Add dynamically generated GitHub Trophy on your readme
 
 ## Tools
 


### PR DESCRIPTION
I developed the GitHub Profile Trophy using Deno.
https://github.com/ryo-ma/github-profile-trophy
Original services using Deno are currently rare.

<img width="1011" src="https://user-images.githubusercontent.com/6661165/94132374-2b1d9880-fe9a-11ea-82be-0901fc039e4d.png">
