### PR TITLE
Add OctoLinker

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 - [elm-live-reload](https://github.com/jinjor/deno-playground/tree/master/elm-live-reload) - An elm live reloader written in Deno.
 - [make-deno-edition](https://github.com/bevry/make-deno-edition) - Automatically makes package.json projects (such as npm packages and node.js modules) compatible with Deno.
 - [nessie](https://github.com/halvardssm/deno-nessie) - Create, migrate and rollback migrations for PostgreSQL, MySQL and SQLite.
+- [OctoLinker](https://octolinker.now.sh) - Navigate through TypeScript and JavaScript files efficiently with the OctoLinker browser extension for GitHub.
 - [packer-provisioner-deno](https://github.com/dontlaugh/packer-provisioner-deno) - A Packer plugin that makes it easy to build virtual machine images with Deno scripts.
 - [pagic](https://github.com/xcatliu/pagic) - The easiest way to generate static html page from markdown, built with Deno.
 - [pika Deno plugin](https://github.com/pikapkg/builders/tree/master/packages/plugin-build-deno/)


### PR DESCRIPTION
[OctoLinker](https://octolinker.now.sh) is a browser extension for GitHub, that turns language-specific statements like `import`, `require` or `include` into links.

[OctoLinker on GitHub](https://github.com/OctoLinker/browser-extension)