### PR TITLE
Add www.soubai.me to whitelist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
           ruby-version: 2.6.x
       - run: |
           gem install awesome_bot
-          awesome_bot README.md --allow 429 --allow-redirect -w https://deno.land/x/,https://deno.land/std/,https://deno.land,https://deno.js.cn
+          awesome_bot README.md --allow 429 --allow-redirect -w https://deno.land/x/,https://deno.land/std/,https://deno.land,https://deno.js.cn,https://www.soubai.me


### PR DESCRIPTION
https://www.soubai.me/posts/create-interactive-mail-utility-cli-with-deno
This page includes some broken image references, and probably that causes the ci error.

This PR adds it to url-check whitelist to prevent the CI error.