### PR TITLE
Add graphql-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 - [garn-validator](https://github.com/jupegarnica/garn-validator) - Create validations with ease.
 - [gentleRpc](https://github.com/timonson/gentleRpc) - A JSON-RPC 2.0 TypeScript library for Deno and the browser.
 - [gql](https://github.com/deno-libs/gql) - Universal GraphQL HTTP middleware.
+- [graphql-tag](https://github.com/deno-libs/graphql-tag) - GraphQL schema AST from template literal. 
 - [http](https://github.com/denoland/deno_std/tree/master/http) - HTTP module including a file server.
 - [invert-kv](https://github.com/denorg/invert-kv) - Invert key-value pairs in Deno.
 - [lazy](https://github.com/luvies/lazy) - A linq-like lazy-evaluation iteration module.


### PR DESCRIPTION
**Link**: https://github.com/deno-libs/graphql-tag

**Description**: this is a Deno port of a [graphql-tag](https://github.com/apollographql/graphql-tag) library, often used to create typedefs that get consumed by `makeExecutableSchema`.

as other libraries I submitted, this one has a few tests and autogenerated docs

