### PR TITLE
Add MaxmindDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 - [lazy](https://github.com/luvies/lazy) - A linq-like lazy-evaluation iteration module.
 - [log](https://github.com/denoland/deno_std/tree/master/log) - Logging module for Deno.
 - [marked](https://github.com/denolib/marked/) - Markdown-to-HTML converter.
+- [maxminddb](https://github.com/josh-hemphill/maxminddb-deno) - A library that enables the usage of MaxmindDB geoIP database files
 - [maze_generator](https://github.com/mjrlowe/maze_generator) - Javascript module for generating, solving, analyzing and displaying mazes.
 - [merlin](https://github.com/crewdevio/merlin) - Testing and Benchmarking framework for deno 🧙‍♂️
 - [microraptor](https://github.com/matteocrippa/microraptor) - Lightweight framework for easy network routing with validation.


### PR DESCRIPTION
Module name is actually just [MaxmindDb](https://deno.land/x/maxminddb@v1.2.0/mod.ts) even though the github path is maxminddb-deno.