### PR TITLE
Add superfetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 - [sql-builder](https://github.com/manyuanrong/sql-builder) - An sql query builder.
 - [status](https://github.com/denosaurs/status) - HTTP codes and status utility for Deno.
 - [superdeno](https://github.com/asos-craigmorten/superdeno) - Super-agent driven library for testing Deno HTTP servers.
+- [superfetch](https://github.com/deno-libs/superfetch) - Superdeno-like superagent testing library based on Fetch API. Ported from [node-supertest-fetch](https://github.com/jwalton/node-supertest-fetch).
 - [superoak](https://github.com/asos-craigmorten/superoak) - HTTP assertions for Oak made easy via SuperDeno.
 - [terminal_images](https://github.com/mjrlowe/terminal_images) -  A Deno module and CLI tool for displaying images in the terminal. 
 - [textproto](https://github.com/denoland/deno_std/tree/master/textproto)


### PR DESCRIPTION
Repo link: https://github.com/deno-libs/superfetch

Description:

superfetch is a Superdeno-like superagent testing library based on Fetch API, ported from node-supertest-fetch.

Example:

```js
import { describe, it, run } from 'https://deno.land/x/tincan/mod.ts'
import { App } from 'https://deno.land/x/tinyhttp@0.1.6/app.ts'
import { makeFetch } from 'https://deno.land/x/superfetch/mod.ts'
import { ServerRequest } from 'https://deno.land/std@0.97.0/http/server.ts'

describe('makeFetch', () => {
  it('should work with tinyhttp', async () => {
    const s = new App().use((req) => req.respond({ body: 'Hello World' }))

    const fetch = makeFetch(s.attach as (req: ServerRequest) => void)

    await fetch('/').expect('Hello World')
  })
})

run()
```