### PR TITLE
Add ghosind/dvm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
   - [justjavac/dvm](https://github.com/justjavac/dvm) - Deno Version Manager: manage multiple active Deno versions.
   - [axetroy/dvm](https://github.com/axetroy/dvm) - Version manger for Deno without runtime dependencies.
   - [dvm.cmd](https://github.com/MarkTiedemann/dvm.cmd) - Deno Version Manager for Windows. Written as a single batch file.
+  - [ghosind/dvm](https://github.com/ghosind/dvm) - A lightweight Deno Version Manager for Linux/MacOS.
 - [elm-live-reload](https://github.com/jinjor/deno-playground/tree/master/elm-live-reload) - An elm live reloader written in Deno.
 - [kopo-cli](https://github.com/littletof/kopo-cli) - A Deno registry browser in the terminal.
 - [lume](https://github.com/lumeland/lume) - A static site generator similar to Jekyll or Eleventy with support for multiple file formats.


### PR DESCRIPTION
A simple dvm for Linux/MacOS, implemented by shellscript. [https://github.com/ghosind/dvm](https://github.com/ghosind/dvm)