### PR TITLE
Add vim-denops/denops.vim in new section Ecosystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This list is a collection of the best Deno modules and resources.
   - [Webview](#webview)
   - [XML](#xml)
 - [Registries](#registries)
+- [Ecosystems](#ecosystems)
 - [Showcases](#showcases)
 - [Tools](#tools)
 - [Articles](#articles)
@@ -240,6 +241,10 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 - [Deno PKG](https://denopkg.com/) - An easier way to use code from GitHub in your Deno project.
 - [deno.land/x/](https://deno.land/x/) - The official 3rd party module registry.
 - [nest.land](https://nest.land) - An immutable, blockchain powered Deno package registry. 🥚
+
+## Ecosystems
+
+- [Denops](https://github.com/vim-denops/denops.vim) - 🐜 An ecosystem to write Vim/Neovim plugins with Deno.
 
 ## Showcases
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This list is a collection of the best Deno modules and resources.
   - [Automation](#automation)
   - [CLI utils](#cli-utils)
   - [Database](#database)
+  - [Editor framework](#editor-framework)
   - [Frontend development](#frontend-development)
   - [Frontend framework](#frontend-framework)
   - [Logging](#logging)
@@ -31,7 +32,6 @@ This list is a collection of the best Deno modules and resources.
   - [Webview](#webview)
   - [XML](#xml)
 - [Registries](#registries)
-- [Ecosystems](#ecosystems)
 - [Showcases](#showcases)
 - [Tools](#tools)
 - [Articles](#articles)
@@ -100,6 +100,10 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 - [maxminddb](https://github.com/josh-hemphill/maxminddb-deno) - A library that enables the usage of MaxmindDB geoIP database files
 - [cotton](https://github.com/rahmanfadhil/cotton) - SQL Database Toolkit for deno
 - [yongo](https://github.com/yooneskh/yongo) - Subset of Mongoose api in deno (like populate) but will not fully copy mongoose
+
+### Editor framework
+
+- [Denops](https://github.com/vim-denops/denops.vim) - 🐜 An ecosystem to write Vim/Neovim plugins with Deno.
 
 ### Frontend development
 - [postcss](https://github.com/postcss/postcss-deno) - A tool for transforming styles with JS plugins.
@@ -241,10 +245,6 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 - [Deno PKG](https://denopkg.com/) - An easier way to use code from GitHub in your Deno project.
 - [deno.land/x/](https://deno.land/x/) - The official 3rd party module registry.
 - [nest.land](https://nest.land) - An immutable, blockchain powered Deno package registry. 🥚
-
-## Ecosystems
-
-- [Denops](https://github.com/vim-denops/denops.vim) - 🐜 An ecosystem to write Vim/Neovim plugins with Deno.
 
 ## Showcases
 


### PR DESCRIPTION
Additional context: [Denops](https://github.com/vim-denops/denops.vim) is a ecosystem to write vim/neovim plugins with deno. Some plugins are already made in Denops ( https://github.com/search?p=1&q=denops&type=Repositories ). For example, https://github.com/Shougo/ddc.vim is a vim plugin written in Denops that provides sub-plugin system that also can be written in Deno ( https://github.com/topics/ddc-vim ).

It should be a good illustration that Deno has power to construct plugin system, sometimes replacing Node.js, Lua, etc...

~I wish (and believe) more things will be added in Ecosystem section in the future, so I made a new section.~
EDIT: move it into modules/editor-framework