### PR TITLE
Add with-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 - [cliffy](https://github.com/c4spar/deno-cliffy) - The complete solution for building interactive command-line tools.
 - [kia](https://github.com/HarryPeach/kia) - Simple terminal spinners for Deno 🦕
 - [terminal_images](https://github.com/mjrlowe/terminal_images) -  A Deno module and CLI tool for displaying images in the terminal.
+- [with-env](https://github.com/bcheidemann/with-env) - Simple command line utilty for executing commands with one or more .env files.
 
 ### Database
 - [deno_mysql](https://github.com/denodrivers/mysql) - MySQL database driver.


### PR DESCRIPTION
Simple command line utility for executing commands with one or more .env files. Written with Deno and installed using the `deno install` command - though binaries are also distributed via GitHub.

This is different to existing entries as it is intended to be used as a stand-alone command line utility and not imported as a library.