### PR TITLE
Add `retraigo/cubic-bezier`

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 - [unexpected](https://github.com/unexpectedjs/unexpected) - Extensible BDD assertion toolkit.
 
 ### Utils
-- [bettermap](https://github.com/nekooftheabyss/bettermap) - A TypeScript extension of the JavaScript Map with Array-like features.
+- [bettermap](https://github.com/retraigo/bettermap) - A TypeScript extension of the JavaScript Map with Array-like features.
 - [buckets](https://github.com/jacoborus/deno-buckets) - Bundle assets and scripts in a single executable file.
 - [bytes_formater](https://github.com/manyuanrong/bytes_formater) - Format bytes (Uint8Array, ArrayBufferView, etc) output, useful when debugging IO functions.
 - [canonify](https://github.com/truestamp/truestamp-canonify) - Stringify data structures to deterministically ordered JSON for consistent hashing and digital signatures per JCS [RFC8785](https://datatracker.ietf.org/doc/html/rfc8785).
@@ -212,11 +212,11 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 - [deno-using](https://github.com/hayd/deno-using) - An python-style with statements for deno.
 - [deno-validation](https://github.com/ethandunford/deno-validation) - A general purpose validation library for Deno.
 - [dinoenv](https://deno.land/x/dinoenv) - tiny library to manage environment variables with deno.
-- [durationjs](https://github.com/nekooftheabyss/duration.js) - Get time duration from a timestamp or a human-readable string.
+- [durationjs](https://github.com/retraigo/duration.js) - Get formatted time duration from a timestamp or a human-readable string.
 - [ensure](https://github.com/eankeen/ensure) - Ensure you are running a minimum version of Deno, Typescript, or V8.
 - [evt](https://github.com/garronej/evt) - Type safe replacement for EventEmitter.
 - [fastest-validator](https://github.com/icebob/fastest-validator) - Schema validator for all javascript platforms
-- [fortuna](https://github.com/queenochaos/fortuna) - Weighted gacha system.
+- [fortuna](https://github.com/retraigo/fortuna) - Weighted gacha system.
 - [fossil](https://github.com/matteocrippa/fossil) - A value-type validation suite.
 - [garn-yaml](https://github.com/jupegarnica/garn-yaml) - Read or write yaml interpolating env variables.
 - [garn-validator](https://github.com/jupegarnica/garn-validator) - Create validations with ease.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Consider submitting to the [deno.land/x](https://deno.land/x/) registry.
 - [canonify](https://github.com/truestamp/truestamp-canonify) - Stringify data structures to deterministically ordered JSON for consistent hashing and digital signatures per JCS [RFC8785](https://datatracker.ietf.org/doc/html/rfc8785).
 - [coffee](https://github.com/irandeno/coffee) - Deno Configuration - a type-safe, easy to use Deno config manager.
 - [computed_types](https://github.com/neuledge/computed-types) - Joi like validators for Typescript and Deno.
+- [cubic-bezier](https://github.com/retraigo/cubic-bezier) - Get an array of points in a cubic bezier curve or visualize in a canvas.
 - [dcc](https://github.com/BoltDoggy/deno#dcc) - Deno Cache Clean, reloading deps when next running.
 - [denon](https://github.com/denosaurs/denon/blob/master/mod.ts) - A file watcher with a for-await generator.
 - [deno-config](https://github.com/yooneskh/deno-config) - Utility to streamline deno app configuration management through cli, .env and json files


### PR DESCRIPTION
- Add `retraigo/cubic-bezier`
    - A module for getting an array of points in a cubic bezier curve or visualizing the curve with canvas. https://github.com/retraigo/cubic-bezier
- Fix URL of `bettermap`, `fortuna` and `durationjs`
- Give `durationjs` a better description