### PR TITLE
Add Switcher4Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ This list is a collection of the best Deno modules and resources.
 - [recursive-readdir](https://github.com/denorg/recursive-readdir) - Recursively read directories in Deno.
 - [rubico](https://github.com/richytong/rubico) - 🏞 [a]synchronous function composition; it just works.
 - [solc](https://github.com/deno-web3/solc) - 💎 Solidity bindings for Deno.
+- [switcher4deno](https://github.com/switcherapi/switcher-client-deno) - Feature Flag Deno SDK client for Switcher-API.
 - [tryify](https://github.com/twilsoft/tryify) - Functional style error handling; never throw/try/catch/finally again.
 - [type-fest](https://github.com/denoserverless/type-fest) - A collection of essential TypeScript types (port of sindresorhus/type-fest).
 - [unified-deno-lock](https://github.com/yooneskh/unified-deno-lock) - Powerful and simple lock (mutex) library to handle race conditions with zero dependencies


### PR DESCRIPTION
Switcher4Deno is part of Switcher-API project, an Open Source feature manager.

Module repository:
https://github.com/switcherapi/switcher-client-deno

Organization site:
https://github.com/switcherapi