### PR TITLE
Add Validator4Oak

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ This list is a collection of the best Deno modules and resources.
 - [hono](https://github.com/honojs/hono) - Ultrafast web framework for Cloudflare Workers, Deno, and Bun. Fast, but not only fast.
 - [oak](https://github.com/oakserver/oak) - A middleware framework for Deno's net server.
   - [oak-http-proxy](https://github.com/asos-craigmorten/oak-http-proxy) - Proxy middleware for Deno Oak HTTP servers.
+  - [validator4oak](https://github.com/petruki/validator4oak) - A middleware for validating/sanitizing requests in Oak HTTP servers.
 - [opine](https://github.com/asos-craigmorten/opine) - Fast, minimalist web framework ported from ExpressJS.
   - [opine-http-proxy](https://github.com/asos-craigmorten/opine-http-proxy) - Proxy middleware for Deno Opine HTTP servers.
 - [wren](https://github.com/zaiste/wren) - A small, but powerful HTTP library with a functional spin for creating composable web apps, built for convenience and simplicity


### PR DESCRIPTION
Validator4Oak is a middleware for request validation/sanitization to be used with Oak HTTP servers.

There is an existing module [oak-middleware-validator](https://github.com/halvardssm/oak-middleware-validator), but has not been updated for more than 4 years and it doesn't work with Oak latest versions.

Module repository: 
https://github.com/petruki/validator4oak