### PR TITLE
Add oak-routing-ctrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ This list is a collection of the best Deno modules and resources.
 - [hono](https://github.com/honojs/hono) - Ultrafast web framework for Cloudflare Workers, Deno, and Bun. Fast, but not only fast.
 - [oak](https://github.com/oakserver/oak) - A middleware framework for Deno's net server.
   - [oak-http-proxy](https://github.com/asos-craigmorten/oak-http-proxy) - Proxy middleware for Deno Oak HTTP servers.
+  - [oak-routing-ctrl](https://github.com/Thesephi/oak-routing-ctrl) - TypeScript Decorators for easy scaffolding API services with the oak framework.
 - [opine](https://github.com/asos-craigmorten/opine) - Fast, minimalist web framework ported from ExpressJS.
   - [opine-http-proxy](https://github.com/asos-craigmorten/opine-http-proxy) - Proxy middleware for Deno Opine HTTP servers.
 - [wren](https://github.com/zaiste/wren) - A small, but powerful HTTP library with a functional spin for creating composable web apps, built for convenience and simplicity


### PR DESCRIPTION
Hello maintainers,

If possible, I'd love to propose an addition to our awesome-deno list: `oak-routing-ctrl`: https://github.com/Thesephi/oak-routing-ctrl

I trust that the project README already explains itself, but a TL;DR version: this library provisions TypeScript Decorators allowing for easy scaffolding API services built with the `@oak/oak` framework (which is directly listed above in this same list).

If further info is needed please comment below. I'm happy to elaborate :)

Thank you all 🍻