### PR TITLE
Add ShopSavvy Deno Deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ This list is a collection of the best Deno modules and resources.
 - [Fresh Showcase](https://fresh.deno.dev/showcase) - The official showcase of Fresh apps.
 - [GitHub Profile Trophy](https://github.com/ryo-ma/github-profile-trophy) - 🏆 Add dynamically generated GitHub Trophy on your readme
 - [Saleor Deno Merch](https://github.com/saleor/deno-merch) - A fork of the original Deno Merch e-commerce website, rebuilt with [Saleor](https://github.com/saleor/saleor).
+- [ShopSavvy Deno Deploy](https://github.com/shopsavvy/deno-deploy-shopsavvy) - Deno Deploy router with Hono for product search, real-time pricing, and price history.
 - [The Official Showcase](https://deno.land/showcase) - The official showcase of Deno.
 - [UsingDeno](https://usingdeno.com) - Curated list of Web Applications & Projects using Deno 🦕.
 


### PR DESCRIPTION
Adds [deno-deploy-shopsavvy](https://github.com/shopsavvy/deno-deploy-shopsavvy) to the **Showcases** section.

A Deno Deploy router with Hono for product search, real-time pricing, and price history. Placed alphabetically between Saleor Deno Merch and The Official Showcase.