### PR TITLE
Ignore medium.com in link check

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -12,6 +12,9 @@
       "pattern": "^https://medium\\.com/"
     },
     {
+      "pattern": "https://segmentfault.com/a/1190000015151287"
+    },
+    {
       "pattern": "https://www.mycompiler.io/new/deno"
     },
     {

--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -9,6 +9,9 @@
   ],
   "ignorePatterns": [
     {
+      "pattern": "^https://medium\\.com/"
+    },
+    {
       "pattern": "https://www.mycompiler.io/new/deno"
     },
     {


### PR DESCRIPTION
Add medium.com and a segmentfault.com article to markdown-link-check ignorePatterns since they return 403/connection errors to non-browser clients but are still live.