### PR TITLE
feat: add TWZRD Agent Intel — x402 micropayment API for Deno AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ This list is a collection of the best Deno modules and resources.
 ### Cloud APIs
 - [aws-api](https://aws-api.deno.dev/) - From-scratch Typescript AWS API client built for Deno.
 - [googleapis](https://googleapis.deno.dev/) - Auto-generated Google API clients for Deno.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring and x402 micropayment verification for AI agents on Solana. Works with Deno's native fetch; zero-install MCP endpoint.
 
 ### Database
 - [@iuioiua/redis](https://jsr.io/@iuioiua/redis) - Fast, lightweight Redis client built upon the Web Streams API.


### PR DESCRIPTION
## Description

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Cloud APIs** section.

TWZRD Agent Intel is a trust scoring and x402 micropayment verification API for AI agents on Solana, usable from Deno via native `fetch`:

- **Free**: wallet trust scoring and agent reputation checks (no auth required)
- **Paid**: `get_trust_receipt` via HTTP 402 + USDC micropayment (x402 standard)
- **Zero-install MCP**: works with Deno's native fetch — `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`

Placed alphabetically in the Cloud APIs section.