### PR TITLE
Add envapt to Utils: typed, zero-dependency environment variables for Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ This list is a collection of the best Deno modules and resources.
 - [denon](https://github.com/denosaurs/denon/blob/master/mod.ts) - A file watcher with a for-await generator.
 - [dinoenv](https://deno.land/x/dinoenv) - tiny library to manage environment variables with deno.
 - [durationjs](https://github.com/retraigo/duration.js) - Get formatted time duration from a timestamp or a human-readable string.
+- [envapt](https://github.com/materwelonDhruv/envapt) - Read environment variables as typed values with built-in converters, Standard Schema validation, and zero dependencies.
 - [esm-itter](https://github.com/tillsanders/esm-itter) – A strongly typed fork of the popular EventEmitter3 with a focus on EcmaScript module syntax, TypeScript and modern tooling.
 - [evt](https://github.com/garronej/evt) - Type safe replacement for EventEmitter.
 - [fastest-validator](https://github.com/icebob/fastest-validator) - Schema validator for all javascript platforms


### PR DESCRIPTION
Adds [envapt](https://github.com/materwelonDhruv/envapt) to Modules → Utils.

**What it is:** envapt reads environment variables (and `.env` files) as typed
values, with built-in converters, Standard Schema validation (zod/valibot/arktype),
and zero runtime dependencies.

**Deno support:** published to JSR as [`@materwelon/envapt`](https://jsr.io/@materwelon/envapt)
(`deno add jsr:@materwelon/envapt`), Deno >= 2.5, tested and documented at
https://envapt.materwelon.dev.

**How it differs from similar Utils entries:**
- vs `dinoenv` (tiny env-var manager, Deno-only): envapt returns typed values
  (number, boolean, bigint, JSON, URL, RegExp, Date, durations, arrays) instead of
  raw strings, with a fallback that removes `undefined` from the return type, and it
  runs unchanged on Node, Bun, Cloudflare Workers, and the browser.
- vs `deno-config` (merges cli + .env + json config): envapt focuses on typed reads
  of individual variables with converters and Standard Schema validation, plus a
  `@Envapt` decorator for binding values to class fields, rather than merging config sources.