### PR TITLE
Add csv-pipe to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ This list is a collection of the best Deno modules and resources.
 - [colors](https://github.com/retraigo/colors) - Color conversions and operations in TypeScript.
 - [computed_types](https://github.com/neuledge/computed-types) - Joi like validators for Typescript and Deno.
 - [croner](https://github.com/Hexagon/croner) - Cron library with advanced scheduling features, well-documented API, and zero dependencies.
+- [csv-pipe](https://github.com/martsinlabs/csv-pipe) - Typed, zero-dependency CSV parser and encoder for every runtime.
 - [deno-config](https://github.com/yooneskh/deno-unified-config) - Utility to streamline deno app configuration management through cli, .env and json files
 - [deno_kv_fs](https://github.com/hviana/deno_kv_fs) Deno KV file system, compatible with Deno deploy. Makes use of Web Streams API.
 - [denon](https://github.com/denosaurs/denon/blob/master/mod.ts) - A file watcher with a for-await generator.


### PR DESCRIPTION
Adds csv-pipe to the Utils section (placed alphabetically).

csv-pipe is a typed, zero-dependency CSV parser and encoder. It is built on web standards and works on Deno via npm:csv-pipe, as well as Node, the browser, Bun, and edge. MIT licensed, with a conformance suite and benchmarks in CI.